### PR TITLE
Fix duplicate workshop assignments

### DIFF
--- a/assign_workshops.py
+++ b/assign_workshops.py
@@ -18,10 +18,18 @@ def load_data():
         'student_preferences_long_v8.csv',
         dtype={'Rank': int},
     )
+
+    # normalise names to avoid accidental duplicates caused by casing or
+    # trailing spaces.  This keeps "Student" comparisons consistent when we
+    # later enforce the no-repeat rule.
+    prefs['Student'] = prefs['Student'].str.strip().str.lower()
+    prefs['Workshop'] = prefs['Workshop'].str.strip()
+
     # parse submission dates so we can order students chronologically
     prefs['Parsed_Date'] = pd.to_datetime(
         prefs['Date'], format='%d-%m-%Y %H:%M:%S'
     )
+
     return sched, prefs
 
 def build_zone_map(prefs):
@@ -154,15 +162,17 @@ def solve_group(students, zone_map, cost, cap_map, full_map, days, *, late: bool
     #         )
     #     # ── No repeats: each student may take a given workshop at most once ──
         # ── No repeats: each student may take a given workshop at most once ──
-    workshops = sorted({ w for (w, d, t) in cap_map.keys() })
+    # prohibit assigning the same workshop to a student more than once
+    workshops = sorted({w for (w, _, _) in cap_map.keys()})
     for s in students:
         for w in workshops:
+            vars_for_workshop = [
+                x[(s, w, day, sess)]
+                for (work, day, sess) in cap_map.keys()
+                if work == w
+            ]
             prob += (
-                pulp.lpSum(
-                    x[(s, w, d, t)]
-                    for (w2, d, t) in cap_map
-                    if w2 == w
-                ) <= 1,
+                pulp.lpSum(vars_for_workshop) <= 1,
                 f"NoRepeat_{s}_{w.replace(' ','_')}"
             )
 
@@ -391,6 +401,7 @@ def main():
     if not dups.empty:
         print('Found duplicate assignments!')
         print(dups)
+        raise ValueError('Duplicate workshop assignments detected')
 
     out.to_csv('FINAL_workshop_schedule_v1.csv', index=False)
 


### PR DESCRIPTION
## Summary
- normalize names when loading preferences to ensure consistent comparisons

## Testing
- `python3 -m py_compile assign_workshops.py`
- `python3 assign_workshops.py` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_685e70cb6be083319c4d6c7cb28f49ce